### PR TITLE
add plugin - babel/plugin-proposal-class-properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",
+    "@babel/plugin-proposal-class-properties": "^7.4.4",
     "@babel/preset-env": "^7.4.3",
     "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,13 @@ const HtmlPlugin = new HtmlWebPackPlugin({
         use: {
           loader: 'babel-loader',
           options: {
-            presets: ['@babel/react', '@babel/env'] // presets could also live in a separate babelrc file
+            presets: [  // presets could also live in a separate babelrc file
+              '@babel/react',
+              '@babel/env',
+              {
+                'plugins': ['@babel/plugin-proposal-class-properties']
+              }
+            ]
           }
         }
       }


### PR DESCRIPTION
this experimental plugin allows shorthand for having state without a constructor in a class component

for example:

```
class App extends React.Component {
    state = {
        count: 0
    }
}
```